### PR TITLE
fix: Debug and resolve failing test suite errors

### DIFF
--- a/app/Models/TrainingSession.php
+++ b/app/Models/TrainingSession.php
@@ -18,30 +18,35 @@ class TrainingSession extends Model
 
     public function techniques()
     {
-        return $this->belongsToMany(Technique::class);
+        return $this->belongsToMany(Technique::class)
+            ->withPivot('done', 'order')
+            ->withTimestamps();
     }
 
     public function getRandomTechnique(): Technique
     {
         //if all techniques are done, set all to not done
-        if ($this->techniques()->wherePivot('done', 0)->count() === 0) {
-            $this->techniques()->updateExistingPivot($this->techniques()->pluck('techniques.id'), ['done' => 0]);
+        $undoneCount = $this->techniques()->wherePivot('done', false)->count();
+        if ($undoneCount === 0) {
+            $techniqueIds = $this->techniques()->pluck('techniques.id');
+            $this->techniques()->updateExistingPivot($techniqueIds, ['done' => false, 'order' => 0]);
         }
         //get random techqniue that is not done
         try {
             //set done
-            $technique = $this->techniques()->wherePivot('done', 0)->get()->random();
-            $this->techniques()->updateExistingPivot($technique->id, ['done' => 1]);
+            $undoneTechniques = $this->techniques()->wherePivot('done', false)->get();
+            $technique = $undoneTechniques->random();
+            $this->techniques()->updateExistingPivot($technique->id, ['done' => true]);
 
             //set order
             //get highest order in this training session
-            $highestOrder = $this->techniques()->wherePivot('done', 1)->max('order');
+            $highestOrder = $this->techniques()->wherePivot('done', true)->max('order') ?? 0;
             //increment by one and set order
             $technique->setOrderForTrainingSession($this, $highestOrder+1);
             return $technique;
         }
         catch (\Exception $e) {
-            throw new \Exception('Could not get random technique');
+            throw new \Exception('Could not get random technique: ' . $e->getMessage());
         }
     }
 

--- a/tests/Feature/GetRandomTechniqueNoRepeatsTest.php
+++ b/tests/Feature/GetRandomTechniqueNoRepeatsTest.php
@@ -10,16 +10,20 @@ use Tests\TestCase;
 
 class GetRandomTechniqueNoRepeatsTest extends TestCase
 {
-
+    use RefreshDatabase;
+    
     //set up
     protected function setUp(): void
     {
         parent::setUp();
+        
+        // Seed the database with the full DatabaseSeeder
+        $this->seed();
+        
         $this->training_session = TrainingSession::factory()->create();
         //attach 10 techniques to the training session
         $techniques = Technique::inRandomOrder()->take(10)->get();
         $this->training_session->techniques()->attach($techniques);
-        echo "Training Session ID is: " .$this->training_session->id;
     }
     /**
      * Test get random technique no repeats.

--- a/tests/Feature/SetTechniqueDoneForTrainingSessionTest.php
+++ b/tests/Feature/SetTechniqueDoneForTrainingSessionTest.php
@@ -10,10 +10,16 @@ use Tests\TestCase;
 
 class SetTechniqueDoneForTrainingSessionTest extends TestCase
 {
+    use RefreshDatabase;
+    
     //set up
     protected function setUp(): void
     {
         parent::setUp();
+        
+        // Seed the database with the full DatabaseSeeder
+        $this->seed();
+        
         $this->training_session = TrainingSession::factory()->create();
         //get a random technique
         $this->technique = Technique::inRandomOrder()->first();

--- a/tests/Feature/SetTechniqueTrainingSessionOrderWhenShownTest.php
+++ b/tests/Feature/SetTechniqueTrainingSessionOrderWhenShownTest.php
@@ -12,10 +12,15 @@ use Tests\TestCase;
 
 class SetTechniqueTrainingSessionOrderWhenShownTest extends TestCase
 {
-
+    use RefreshDatabase;
+    
     protected function setUp(): void
     {
         parent::setUp();
+        
+        // Seed the database with the full DatabaseSeeder
+        $this->seed();
+        
         $this->training_session = TrainingSession::factory()->create();
         //attach 10 techniques to the training session
         $techniques = Technique::inRandomOrder()->take(10)->get();


### PR DESCRIPTION
- Fixed TrainingSession relationship by adding withPivot('done', 'order') and withTimestamps()
- Fixed null handling in getRandomTechnique() method with null coalescing operator
- Updated boolean value consistency for 'done' column throughout codebase
- Added proper database seeding to test setUp methods using $this->seed()
- Added RefreshDatabase trait to all test classes for proper test isolation

All tests now pass successfully. Resolves issues with technique randomization, training session ordering, and database state management in tests.

🤖 Generated with [Claude Code](https://claude.ai/code)